### PR TITLE
Tweak Python bindings to create standalone sdist package

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2023 Bartosz Golaszewski <bartosz.golaszewski@linaro.org>
 
 include setup.py
+include gpiod-version-str.txt
 
 recursive-include gpiod *.py
 recursive-include tests *.py
@@ -11,3 +12,7 @@ recursive-include gpiod/ext *.h
 
 recursive-include tests/gpiosim *.c
 recursive-include tests/procname *.c
+
+recursive-include lib *.c
+recursive-include lib *.h
+recursive-include include *.h

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -16,6 +16,9 @@ all-local:
 	$(PYTHON) setup.py build_ext --inplace \
 		--include-dirs=$(top_srcdir)/include/:$(top_srcdir)/tests/gpiosim/ \
 		--library-dirs=$(top_builddir)/lib/.libs/:$(top_srcdir)/tests/gpiosim/.libs/
+	GPIOD_VERSION_STR=$(VERSION_STR) \
+	$(PYTHON) setup.py sdist
+
 
 install-exec-local:
 	GPIOD_WITH_TESTS= \

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,10 +1,49 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: 2022 Bartosz Golaszewski <brgl@bgdev.pl>
 
-from os import environ, path
+from os import environ, path, unlink
 from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext as orig_build_ext
-from shutil import rmtree
+from setuptools.command.sdist import sdist as orig_sdist
+from shutil import rmtree, copytree
+
+
+def get_gpiod_version_str():
+    try:
+        return environ["GPIOD_VERSION_STR"]
+    except KeyError:
+        pass
+    try:
+        return open("gpiod-version-str.txt", "r").read()
+    except OSError:
+        return None
+
+
+def copy_libgpiod_files(func):
+    """
+    In order to include the lib and include directories in the sdist
+    we must temporarily copy them up into the python bindings directory.
+
+    If "./lib" exists we are building from an sdist package and will not
+    try to copy the files again.
+    """
+
+    def wrapper(self):
+        copy_src = not path.exists("./lib")
+        if copy_src:
+            gpiod_version_str = get_gpiod_version_str()
+            if gpiod_version_str is not None:
+                open("gpiod-version-str.txt", "w").write(gpiod_version_str)
+            copytree("../../lib", "./lib")
+            copytree("../../include", "./include")
+        func(self)
+        if copy_src:
+            if gpiod_version_str is not None:
+                unlink("gpiod-version-str.txt")
+            rmtree("./lib")
+            rmtree("./include")
+
+    return wrapper
 
 
 class build_ext(orig_build_ext):
@@ -14,24 +53,78 @@ class build_ext(orig_build_ext):
     were built (and possibly copied to the source directory if inplace is set).
     """
 
+    @copy_libgpiod_files
     def run(self):
         super().run()
         rmtree(path.join(self.build_lib, "tests"), ignore_errors=True)
 
 
+class sdist(orig_sdist):
+    """
+    Wrap sdist so that we can copy the lib and include files into . where
+    MANIFEST.in will include them in the source package.
+    """
+
+    @copy_libgpiod_files
+    def run(self):
+        super().run()
+
+
+with open("gpiod/version.py", "r") as fd:
+    exec(fd.read())
+
+sources = [
+    # gpiod Python bindings
+    "gpiod/ext/chip.c",
+    "gpiod/ext/common.c",
+    "gpiod/ext/line-config.c",
+    "gpiod/ext/line-settings.c",
+    "gpiod/ext/module.c",
+    "gpiod/ext/request.c",
+]
+
+extra_compile_args = [
+    "-Wall",
+    "-Wextra",
+]
+
+libraries = ["gpiod"]
+include_dirs = ["gpiod"]
+
+if environ.get("LINK_SYSTEM_LIBGPIOD") == "1":
+    print("linking system libgpiod (requested by LINK_SYSTEM_LIBGPIOD)")
+elif get_gpiod_version_str() is None:
+    print("warning: linking system libgpiod (GPIOD_VERSION_STR not specified)")
+else:
+    print("vendoring libgpiod into standalone library")
+    sources += [
+        # gpiod library
+        "lib/chip.c",
+        "lib/chip-info.c",
+        "lib/edge-event.c",
+        "lib/info-event.c",
+        "lib/internal.c",
+        "lib/line-config.c",
+        "lib/line-info.c",
+        "lib/line-request.c",
+        "lib/line-settings.c",
+        "lib/misc.c",
+        "lib/request-config.c",
+    ]
+    libraries = []
+    include_dirs = ["include", "lib", "gpiod/ext"]
+    extra_compile_args += [
+        '-DGPIOD_VERSION_STR="{}"'.format(get_gpiod_version_str()),
+    ]
+
+
 gpiod_ext = Extension(
     "gpiod._ext",
-    sources=[
-        "gpiod/ext/chip.c",
-        "gpiod/ext/common.c",
-        "gpiod/ext/line-config.c",
-        "gpiod/ext/line-settings.c",
-        "gpiod/ext/module.c",
-        "gpiod/ext/request.c",
-    ],
+    libraries=libraries,
+    sources=sources,
     define_macros=[("_GNU_SOURCE", "1")],
-    libraries=["gpiod"],
-    extra_compile_args=["-Wall", "-Wextra"],
+    include_dirs=include_dirs,
+    extra_compile_args=extra_compile_args,
 )
 
 gpiosim_ext = Extension(
@@ -54,15 +147,12 @@ if environ.get("GPIOD_WITH_TESTS") == "1":
     extensions.append(gpiosim_ext)
     extensions.append(procname_ext)
 
-with open("gpiod/version.py", "r") as fd:
-    exec(fd.read())
-
 setup(
     name="libgpiod",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.9.0",
     ext_modules=extensions,
-    cmdclass={"build_ext": build_ext},
+    cmdclass={"build_ext": build_ext, "sdist": sdist},
     version=__version__,
     author="Bartosz Golaszewski",
     author_email="brgl@bgdev.pl",


### PR DESCRIPTION
:warning: Replaced by #5 
:warning: Submitted upstream - https://lore.kernel.org/linux-gpio/20231013112812.148021-1-phil@gadgetoid.com/T/#t

This changeset vendors the gpiod library into the Python package.

This works by symlinking the `lib` and `include` directories up to the parent module, and updating `MANIFEST.in` to include the source files.

If "LINK_SYSTEM_LIBGPIOD =1" is *not* specified then the `gpiod._ext` C Extension is amended to include all of the C sources for `gpiod`, so it can be built as a standalone module without depending upon a shared distro library.

# Why?

So that it can produce an sdist that is installable irrespective of the availability or version of a distro-supplied libgpiod. This prevents a libgpiod pypi package install balking because the distro libgpiod is outdated or otherwise incompatible. This happens with the [currently available libgpiod on pypi](https://pypi.org/project/libgpiod/).

This also ensures that libgpiod can be installed via pypi into an isolated virtual environment, specified as a dependency for Python packages and allow Python developers to target the newest API version.

# Fallback to system libgpiod

Installing from an sdist with a "LINK_SYSTEM_LIBGPIOD=1" environment variable will drop the vendored library in favour of the system, however the system library must be compatible with the bindings.

# Building

This package has been tested on Raspberry Pi OS (Debian Bookworm based) and Ubuntu Mantic (Pi 5 ARM64 release).

You'll need:

```
sudo apt install git build-essential make autoconf autoconf-archive automake pkg-config libtool
sudo apt install python3-dev python3-setuptools python3-pip python3-wheel python3-venv
```

Then clone this branch:

```
git clone https://github.com/gadgetoid/libgpiod -b python-bindings-3
```

Configure and build:

```
cd libgpiod
./autogen.sh
./configure --enable-bindings-python
make
```

 Create yourself a venv so you can install Python packages:

```
python3 -m venv ~/libgpiod_test_env
source ~/libgpiod_test_env/bin/activate
```

Now you can attempt to install the sdist:

```
pip install bindings/python/dist/libgpiod-2.0.1.tar.gz
```

# Testing

This package should, in theory, work on any platform with Python >= 3.10.0 and GPIO character device support.

To see if you have any supported devices:

```
ls /dev/gpiochip*
```

The following test script should toggle line 15 1000 times and report how long it took-

:warning: Make sure you don't try to `import gpiod` or run the below from the `libgpiod/bindings/python` directory.

```python
import gpiod
import time

CONSUMER = "Benchmark"
LINE = 15

chip = gpiod.Chip("/dev/gpiochip4")

lines = chip.request_lines(consumer=CONSUMER, config={
    LINE: gpiod.LineSettings(
        direction=gpiod.line.Direction.OUTPUT,
        output_value=gpiod.line.Value.INACTIVE
    ) 
})

t_start = time.time()

n = 1000

for x in range(n):
    lines.set_value(LINE, gpiod.line.Value.ACTIVE)
    lines.set_value(LINE, gpiod.line.Value.INACTIVE)

t_end = time.time()

print(f"Toggling {n} times took: {(t_end - t_start) * 1000:0.4f}ms")
```

