### PR TITLE
bindings: python: optionally include module in sdist

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -3,6 +3,7 @@
 
 include setup.py
 include README.md
+include libgpiod-version.txt
 
 recursive-include gpiod *.py
 recursive-include tests *.py
@@ -12,3 +13,7 @@ recursive-include gpiod/ext *.h
 
 recursive-include tests/gpiosim *.c
 recursive-include tests/procname *.c
+
+recursive-include lib *.c
+recursive-include lib *.h
+recursive-include include *.h

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2023 Bartosz Golaszewski <bartosz.golaszewski@linaro.org>
 
 include setup.py
+include README.md
 
 recursive-include gpiod *.py
 recursive-include tests *.py

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: CC-BY-SA-4.0
+# SPDX-FileCopyrightText: 2023 Phil Howard <phil@gadgetoid.com>
+
+# gpiod
+
+These are the official Python bindings for [libgpiod](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/).
+
+The gpiod library has been vendored into this package for your convenience and
+this version of gpiod is independent from your system package.
+
+Binary wheels are not provided. The source package requires python3-dev.
+
+## Rationale
+
+The new character device interface guarantees all allocated resources are
+freed after closing the device file descriptor and adds several new features
+that are not present in the obsolete sysfs interface (like event polling,
+setting/reading multiple values at once or open-source and open-drain GPIOs).
+
+Unfortunately interacting with the linux device file can no longer be done
+using only standard command-line tools. This is the reason for creating a
+library encapsulating the cumbersome, ioctl-based kernel-userspace interaction
+in a set of convenient functions and opaque data structures.
+
+## Breaking Changes
+
+As of v2.0.2 we have replaced the unofficial, pure-Python "gpiod". The official
+gpiod is not backwards compatible.
+
+You should ensure you specify at least v2.0.2 for the official API. Versions
+1.5.4 and prior are the deprecated, unofficial, pure-Python bindings.
+
+## Installing
+
+You will need `python3-dev`, on Debian/Ubuntu you can install this with:
+
+```
+sudo apt install python3-dev
+```
+
+And then install gpiod with:
+
+```
+pip install gpiod
+```
+
+You can optionally depend upon your system gpiod by installing with:
+
+```
+LINK_SYSTEM_LIBGPIOD=1 pip install gpiod
+```
+
+If you still need the deprecated pure-Python bindings, install with:
+
+```
+pip install gpiod==1.5.4
+```
+
+## Examples
+
+Check a GPIO chip character device exists:
+
+```python
+import gpiod
+
+gpiod.is_gpiochip_device("/dev/gpiochip0")
+
+```
+
+Get information about a GPIO chip character device:
+
+```python
+import gpiod
+
+with gpiod.Chip("/dev/gpiochip0") as chip:
+    info = chip.get_info()
+    print(f"{info.name} [{info.label}] ({info.num_lines} lines)")
+```
+
+Blink an LED, or toggling a GPIO line:
+
+```python
+import time
+
+from gpiod.line import Direction, Value
+
+LINE = 5
+
+with gpiod.request_lines(
+    "/dev/gpiochip0",
+    consumer="blink-example",
+    config={
+        LINE: gpiod.LineSettings(
+            direction=Direction.OUTPUT, output_value=Value.ACTIVE
+        )
+    },
+) as request:
+    while True:
+        request.set_value(LINE, Value.ACTIVE)
+        time.sleep(1)
+        request.set_value(LINE, Value.INACTIVE)
+        time.sleep(1)
+```
+

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2023 Phil Howard <phil@gadgetoid.com>
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "packaging"]

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,22 +1,214 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: 2022 Bartosz Golaszewski <brgl@bgdev.pl>
 
-from os import environ, path
-from setuptools import setup, Extension, find_packages
+from os import getenv, path, unlink
+from shutil import copytree, rmtree
+
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext as orig_build_ext
-from shutil import rmtree
+from setuptools.command.sdist import log
+from setuptools.command.sdist import sdist as orig_sdist
+from setuptools.errors import BaseError
+
+LINK_SYSTEM_LIBGPIOD = getenv("LINK_SYSTEM_LIBGPIOD") == "1"
+LIBGPIOD_MINIMUM_VERSION = "2.1.0"
+LIBGPIOD_VERSION = getenv("LIBGPIOD_VERSION")
+GPIOD_WITH_TESTS = getenv("GPIOD_WITH_TESTS") == "1"
+SRC_BASE_URL = "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/"
+TAR_FILENAME = "libgpiod-{version}.tar.gz"
+ASC_FILENAME = "sha256sums.asc"
+SHA256_CHUNK_SIZE = 2048
+
+# __version__
+with open("gpiod/version.py", "r") as fd:
+    exec(fd.read())
+
+
+def sha256(filename):
+    """
+    Return a sha256sum for a specific filename, loading the file in chunks
+    to avoid potentially excessive memory use.
+    """
+    from hashlib import sha256
+
+    sha256sum = sha256()
+    with open(filename, "rb") as f:
+        for chunk in iter(lambda: f.read(SHA256_CHUNK_SIZE), b""):
+            sha256sum.update(chunk)
+
+    return sha256sum.hexdigest()
+
+
+def find_sha256sum(asc_file, tar_filename):
+    """
+    Search through a local copy of sha256sums.asc for a specific filename
+    and return the associated sha256 sum.
+    """
+    with open(asc_file, "r") as f:
+        for line in f:
+            line = line.strip().split("  ")
+            if len(line) == 2 and line[1] == tar_filename:
+                return line[0]
+
+    raise BaseError(f"no signature found for {tar_filename}")
+
+
+def fetch_tarball(command):
+    """
+    Verify the requested LIBGPIOD_VERSION tarball exists in sha256sums.asc,
+    fetch it from https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/
+    and verify its sha256sum.
+
+    If the check passes, extract the tarball and copy the lib and include
+    dirs into our source tree.
+    """
+
+    # If no LIBGPIOD_VERSION is specified in env, just run the command
+    if LIBGPIOD_VERSION is None:
+        return command
+
+    # If LIBGPIOD_VERSION is specified, apply the tarball wrapper
+    def wrapper(self):
+        # Just-in-time import of tarfile and urllib.request so these are
+        # not required for Yocto to build a vendored or linked package
+        import tarfile
+        from tempfile import TemporaryDirectory
+        from urllib.request import urlretrieve
+
+        from packaging.version import Version
+
+        # The "build" frontend will run setup.py twice within the same
+        # temporary output directory. First for "sdist" and then for "wheel"
+        # This would cause the build to fail with dirty "lib" and "include"
+        # directories.
+        # If the version in "libgpiod-version.txt" already matches our
+        # requested tarball, then skip the fetch altogether.
+        try:
+            if open("libgpiod-version.txt", "r").read() == LIBGPIOD_VERSION:
+                log.info(f"skipping tarball fetch")
+                command(self)
+                return
+        except OSError:
+            pass
+
+        # Early exit for build tree with dirty lib/include dirs
+        for check_dir in "lib", "include":
+            if path.isdir(f"./{check_dir}"):
+                raise BaseError(f"refusing to overwrite ./{check_dir}")
+
+        with TemporaryDirectory(prefix="libgpiod-") as temp_dir:
+            tarball_filename = TAR_FILENAME.format(version=LIBGPIOD_VERSION)
+            tarball_url = f"{SRC_BASE_URL}{tarball_filename}"
+            asc_url = f"{SRC_BASE_URL}{ASC_FILENAME}"
+
+            log.info(f"fetching: {asc_url}")
+
+            asc_filename, _ = urlretrieve(asc_url, path.join(temp_dir, ASC_FILENAME))
+
+            tarball_sha256 = find_sha256sum(asc_filename, tarball_filename)
+
+            if Version(LIBGPIOD_VERSION) < Version(LIBGPIOD_MINIMUM_VERSION):
+                raise BaseError(f"requires libgpiod>={LIBGPIOD_MINIMUM_VERSION}")
+
+            log.info(f"fetching: {tarball_url}")
+
+            downloaded_tarball, _ = urlretrieve(
+                tarball_url, path.join(temp_dir, tarball_filename)
+            )
+
+            log.info(f"verifying: {tarball_filename}")
+            if sha256(downloaded_tarball) != tarball_sha256:
+                raise BaseError(f"signature mismatch for {tarball_filename}")
+
+            # Unpack the downloaded tarball
+            log.info(f"unpacking: {tarball_filename}")
+            with tarfile.open(downloaded_tarball) as f:
+                f.extractall(temp_dir)
+
+            # Copy the include and lib directories we need to build libgpiod
+            base_dir = path.join(temp_dir, f"libgpiod-{LIBGPIOD_VERSION}")
+            copytree(path.join(base_dir, "include"), "./include")
+            copytree(path.join(base_dir, "lib"), "./lib")
+
+        # Save the libgpiod version for sdist
+        open("libgpiod-version.txt", "w").write(LIBGPIOD_VERSION)
+
+        # Run the command
+        command(self)
+
+        # Clean up the build directory
+        rmtree("./lib", ignore_errors=True)
+        rmtree("./include", ignore_errors=True)
+        unlink("libgpiod-version.txt")
+
+    return wrapper
 
 
 class build_ext(orig_build_ext):
     """
-    setuptools install all C extentions even if they're excluded in setup().
-    As a workaround - remove the tests directory right after all extensions
-    were built (and possibly copied to the source directory if inplace is set).
+    Wrap build_ext to amend the module sources and settings to build
+    the bindings and gpiod into a combined module when a version is
+    specified and LINK_SYSTEM_LIBGPIOD=1 is not present in env.
+
+    run is wrapped with @fetch_tarball in order to fetch the sources
+    needed to build binary wheels when LIBGPIOD_VERSION is specified, eg:
+
+    LIBGPIOD_VERSION="2.0.2" python3 -m build .
     """
 
+    @fetch_tarball
+    def run(self):
+        # Try to get the gpiod version from the .txt file included in sdist
+        try:
+            libgpiod_version = open("libgpiod-version.txt", "r").read()
+        except OSError:
+            libgpiod_version = LIBGPIOD_VERSION
+
+        if libgpiod_version and not LINK_SYSTEM_LIBGPIOD:
+            # When building the extension from an sdist with a vendored
+            # amend gpiod._ext sources and settings accordingly.
+            gpiod_ext = self.ext_map["gpiod._ext"]
+            gpiod_ext.sources += [
+                "lib/chip.c",
+                "lib/chip-info.c",
+                "lib/edge-event.c",
+                "lib/info-event.c",
+                "lib/internal.c",
+                "lib/line-config.c",
+                "lib/line-info.c",
+                "lib/line-request.c",
+                "lib/line-settings.c",
+                "lib/misc.c",
+                "lib/request-config.c",
+            ]
+            gpiod_ext.libraries = []
+            gpiod_ext.include_dirs = ["include", "lib", "gpiod/ext"]
+            gpiod_ext.extra_compile_args.append(
+                f'-DGPIOD_VERSION_STR="{libgpiod_version}"',
+            )
+
+        super().run()
+
+        # We don't ever want the module tests directory in our package
+        # since this might include gpiosim._ext or procname._ext from a
+        # previous dirty build tree.
+        rmtree(path.join(self.build_lib, "tests"), ignore_errors=True)
+
+
+class sdist(orig_sdist):
+    """
+    Wrap sdist in order to fetch the libgpiod source files for vendoring
+    into a source distribution.
+
+    run is wrapped with @fetch_tarball in order to fetch the sources
+    needed to build binary wheels when LIBGPIOD_VERSION is specified, eg:
+
+    LIBGPIOD_VERSION="2.0.2" python3 -m build . --sdist
+    """
+
+    @fetch_tarball
     def run(self):
         super().run()
-        rmtree(path.join(self.build_lib, "tests"), ignore_errors=True)
 
 
 gpiod_ext = Extension(
@@ -50,19 +242,17 @@ procname_ext = Extension(
 )
 
 extensions = [gpiod_ext]
-if environ.get("GPIOD_WITH_TESTS") == "1":
+if GPIOD_WITH_TESTS:
     extensions.append(gpiosim_ext)
     extensions.append(procname_ext)
 
-with open("gpiod/version.py", "r") as fd:
-    exec(fd.read())
-
 setup(
     name="gpiod",
+    url="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.9.0",
     ext_modules=extensions,
-    cmdclass={"build_ext": build_ext},
+    cmdclass={"build_ext": build_ext, "sdist": sdist},
     version=__version__,
     author="Bartosz Golaszewski",
     author_email="brgl@bgdev.pl",

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -67,8 +67,8 @@ setup(
     author="Bartosz Golaszewski",
     author_email="brgl@bgdev.pl",
     description="Python bindings for libgpiod",
-    long_description="This is a package spun out of the main libgpiod repository containing " \
-                     "python bindings to the underlying C library.",
+    long_description=open("README.md", "r").read(),
+    long_description_content_type="text/markdown",
     platforms=["linux"],
     license="LGPLv2.1",
 )

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -58,7 +58,7 @@ with open("gpiod/version.py", "r") as fd:
     exec(fd.read())
 
 setup(
-    name="libgpiod",
+    name="gpiod",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.9.0",
     ext_modules=extensions,

--- a/bindings/python/tests/__init__.py
+++ b/bindings/python/tests/__init__.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 
-from setuptools._distutils.version import LooseVersion
+from distutils.version import LooseVersion
 
 required_kernel_version = LooseVersion("5.19.0")
 current_version = LooseVersion(os.uname().release.split("-")[0])


### PR DESCRIPTION
MERGED 🎉 

:warning: Submitted upstream - https://lore.kernel.org/linux-gpio/20231018205728.284068-1-phil@gadgetoid.com/T/#t

This changeset vendors the gpiod library into the Python package, by fetching the requested stable release tarball from git.kernel.org, unpacking it, and copying the `lib` and `include` directories into the module source directory.

`MANIFEST.in` has been updated to include the 'lib' and 'include' directories, in addition to a `gpiod-version.txt` which contains the version string that's passed to the vendored libgpiod at build time.

# How

In order to create a package with a vendored libgpiod version, the `GPIOD_VERSION` environment variable must be set with the desired, valid gpiod release, eg:

```
GPIOD_VERSION=2.0.2 python3 setup.py sdist
```

The above will fetch libgpiod-2.0.2.tar.gz, unpack the `lib` and `include` directories and create a source distribution vendoring libgpiod 2.0.2.

# Fallback to system libgpiod

Installing from an sdist with a "LINK_SYSTEM_LIBGPIOD=1" environment variable will drop the vendored library in favour of the system, however the system library must be compatible with the bindings. eg:

```
LINK_SYSTEM_LIBGPIOD=1 pip install libgpiod
```

# Why?

So that it can produce an sdist that is installable irrespective of the availability or version of a distro-supplied libgpiod. This prevents a libgpiod pypi package install balking because the distro libgpiod is outdated or otherwise incompatible. This happens with the [currently available libgpiod on pypi](https://pypi.org/project/libgpiod/).

This also ensures that libgpiod can be installed via pypi into an isolated virtual environment, specified as a dependency for Python packages and allow Python developers to target the newest API version.

# Building

This package has been tested on Raspberry Pi OS (Debian Bookworm based) and Ubuntu Mantic (Pi 5 ARM64 release).

You'll need:

```
sudo apt install git build-essential
sudo apt install python3-dev python3-setuptools python3-pip python3-wheel python3-venv
```

Then clone this branch:

```
git clone https://github.com/gadgetoid/libgpiod -b python-bindings-4
```

Build a vendored sdist:

```
cd libgpiod/bindings/python
GPIOD_VERSION python3 setup.py sdist bdist_wheel
```

Create yourself a venv so you can install Python packages:

```
python3 -m venv ~/libgpiod_test_env
source ~/libgpiod_test_env/bin/activate
```

Now you can attempt to install the sdist:

```
pip install dist/libgpiod-2.0.1.tar.gz
```

⚠️ Note that the `GPIOD_VERSION` has nothing to do with the version of the *Python bindings*, and instead controls which version of the gpiod C library is vendored into the package.

# Testing

This package should, in theory, work on any platform with Python >= 3.10.0 and GPIO character device support.

To see if you have any supported devices:

```
ls /dev/gpiochip*
```

The following test script should toggle line 15 1000 times and report how long it took-

:warning: Make sure you don't try to `import gpiod` or run the below from the `libgpiod/bindings/python` directory.

```python
import gpiod
import time

CONSUMER = "Benchmark"
LINE = 15

chip = gpiod.Chip("/dev/gpiochip4")

lines = chip.request_lines(consumer=CONSUMER, config={
    LINE: gpiod.LineSettings(
        direction=gpiod.line.Direction.OUTPUT,
        output_value=gpiod.line.Value.INACTIVE
    ) 
})

t_start = time.time()

n = 1000

for x in range(n):
    lines.set_value(LINE, gpiod.line.Value.ACTIVE)
    lines.set_value(LINE, gpiod.line.Value.INACTIVE)

t_end = time.time()

print(f"Toggling {n} times took: {(t_end - t_start) * 1000:0.4f}ms")
```

